### PR TITLE
feat: Add user preferences persistence and theme selection

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11,6 +11,16 @@ CREATE TABLE users (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- USER PREFERENCES
+CREATE TABLE user_preferences (
+    user_id INT PRIMARY KEY,
+    theme_mode VARCHAR(20) NOT NULL DEFAULT 'dark',
+    CONSTRAINT fk_user_preferences_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE
+);
+
 -- CATEGORIES
 -- user_id NULL => system-defined category
 CREATE TABLE categories (

--- a/src/db.py
+++ b/src/db.py
@@ -6,6 +6,7 @@ import os
 
 from dotenv import load_dotenv
 import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sqlalchemy import create_engine, text
 
 logger = logging.getLogger(__name__)

--- a/src/services/preferences_service.py
+++ b/src/services/preferences_service.py
@@ -1,0 +1,52 @@
+"""User preference helpers for PersonalFinanceAnalyzer."""
+
+from __future__ import annotations
+
+from db import execute_query, execute_write, fetch_one
+
+VALID_THEME_MODES = {"dark", "light"}
+
+
+def _normalize_theme_mode(theme_mode: str) -> str:
+    normalized = str(theme_mode).strip().lower()
+    return normalized if normalized in VALID_THEME_MODES else "dark"
+
+
+def get_user_preferences(engine, user_id: int) -> dict[str, str]:
+    row = fetch_one(
+        "SELECT theme_mode FROM user_preferences WHERE user_id = :user_id",
+        {"user_id": user_id},
+        engine=engine,
+    )
+    if row is not None:
+        return {"theme_mode": row["theme_mode"] or "dark"}
+
+    default_theme = "dark"
+    execute_write(
+        "INSERT INTO user_preferences (user_id, theme_mode) VALUES (:user_id, :theme_mode)",
+        {"user_id": user_id, "theme_mode": default_theme},
+        engine=engine,
+    )
+    return {"theme_mode": default_theme}
+
+
+def save_user_preferences(engine, user_id: int, theme_mode: str) -> dict[str, str]:
+    theme_mode = _normalize_theme_mode(theme_mode)
+    existing = fetch_one(
+        "SELECT user_id FROM user_preferences WHERE user_id = :user_id",
+        {"user_id": user_id},
+        engine=engine,
+    )
+    if existing is None:
+        execute_write(
+            "INSERT INTO user_preferences (user_id, theme_mode) VALUES (:user_id, :theme_mode)",
+            {"user_id": user_id, "theme_mode": theme_mode},
+            engine=engine,
+        )
+    else:
+        execute_write(
+            "UPDATE user_preferences SET theme_mode = :theme_mode WHERE user_id = :user_id",
+            {"user_id": user_id, "theme_mode": theme_mode},
+            engine=engine,
+        )
+    return {"theme_mode": theme_mode}

--- a/src/ui/dashboard_page.py
+++ b/src/ui/dashboard_page.py
@@ -24,6 +24,10 @@ from services.finance_service import (
     search_transactions,
     update_transaction_category,
 )
+from services.preferences_service import (
+    get_user_preferences,
+    save_user_preferences,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +38,7 @@ NAVIGATION_OPTIONS = [
     "Transactions",
     "Search / Filter",
     "Reports",
+    "Preferences",
     "Budgeting",
 ]
 
@@ -44,6 +49,7 @@ NAV_ICONS = {
     "Transactions": "☰",
     "Search / Filter": "⌕",
     "Reports": "▤",
+    "Preferences": "⚙",
     "Budgeting": "$",
 }
 
@@ -54,12 +60,24 @@ NAV_DISPLAY = {
     "Transactions": "Transactions",
     "Search / Filter": "Search",
     "Reports": "Reports",
+    "Preferences": "Preferences",
     "Budgeting": "Budgeting",
 }
 
 
-def _resolve_theme_mode() -> str:
-    return "dark"
+def _resolve_theme_mode(engine) -> str:
+    if "theme_mode" in st.session_state:
+        return st.session_state.theme_mode
+
+    if st.session_state.authenticated_user is not None:
+        user_id = int(st.session_state.authenticated_user["id"])
+        preferences = get_user_preferences(engine, user_id)
+        theme_mode = preferences.get("theme_mode", "dark")
+    else:
+        theme_mode = "dark"
+
+    st.session_state.theme_mode = theme_mode
+    return theme_mode
 
 
 def _theme_tokens(theme_mode: str) -> dict[str, str]:
@@ -514,7 +532,7 @@ def _render_dashboard_overview(engine, user_id: int) -> None:
         unsafe_allow_html=True,
     )
 
-    theme_mode = _resolve_theme_mode()
+    theme_mode = _resolve_theme_mode(engine)
     metrics = get_dashboard_metrics(engine, user_id)
     _render_kpi_cards(metrics)
 
@@ -773,6 +791,27 @@ def _render_reports_section(engine, user_id: int) -> None:
     st.dataframe(transactions.head(10), use_container_width=True)
 
 
+def _render_preferences_section(engine, user_id: int) -> None:
+    st.title("Preferences")
+    st.write("Save your dashboard settings so the app matches your workflow.")
+
+    preferences = get_user_preferences(engine, user_id)
+    current_theme = preferences.get("theme_mode", "dark")
+    selected_theme = st.radio(
+        "Theme mode",
+        ["dark", "light"],
+        index=0 if current_theme == "dark" else 1,
+        horizontal=True,
+        key="preferences_theme_mode",
+    )
+
+    if st.button("Save preferences", type="primary"):
+        saved = save_user_preferences(engine, user_id, selected_theme)
+        st.session_state.theme_mode = saved["theme_mode"]
+        st.success("Preferences saved successfully.")
+        st.experimental_rerun()
+
+
 def _render_budgeting_section(engine, user_id: int) -> None:
     st.markdown(
         """
@@ -862,7 +901,7 @@ def _render_budgeting_section(engine, user_id: int) -> None:
             + ", ".join(overspent["category"].astype(str).tolist())
         )
 
-    theme_mode = _resolve_theme_mode()
+    theme_mode = _resolve_theme_mode(engine)
     left_col, right_col = st.columns([1.2, 1], gap="large")
     with left_col:
         viz_frame = recommendations[
@@ -928,7 +967,7 @@ def render_dashboard_page(engine, logout_callback) -> None:
         return
 
     initialize_dashboard_state()
-    theme_mode = _resolve_theme_mode()
+    theme_mode = _resolve_theme_mode(engine)
     _inject_dashboard_styles(theme_mode)
     _render_sidebar(user, logout_callback)
 
@@ -952,5 +991,7 @@ def render_dashboard_page(engine, logout_callback) -> None:
         _render_search_section(engine, int(user["id"]))
     elif section == "Reports":
         _render_reports_section(engine, int(user["id"]))
+    elif section == "Preferences":
+        _render_preferences_section(engine, int(user["id"]))
     elif section == "Budgeting":
         _render_budgeting_section(engine, int(user["id"]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,16 @@ def finance_engine():
         )
         connection.execute(
             text(
+                """
+                CREATE TABLE user_preferences (
+                    user_id INTEGER PRIMARY KEY,
+                    theme_mode TEXT NOT NULL DEFAULT 'dark'
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
                 "INSERT INTO users (id, email, password_hash) VALUES (1, 'user@example.com', 'hash')"
             )
         )

--- a/tests/unit/test_preferences_service.py
+++ b/tests/unit/test_preferences_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from services.preferences_service import (
+    get_user_preferences,
+    save_user_preferences,
+)
+
+
+def test_get_user_preferences_defaults_to_dark(finance_engine) -> None:
+    prefs = get_user_preferences(finance_engine, 1)
+
+    assert prefs["theme_mode"] == "dark"
+
+
+def test_save_user_preferences_updates_existing_record(finance_engine) -> None:
+    save_user_preferences(finance_engine, 1, "light")
+    prefs = get_user_preferences(finance_engine, 1)
+
+    assert prefs["theme_mode"] == "light"
+
+
+def test_save_user_preferences_normalizes_invalid_theme(finance_engine) -> None:
+    prefs = save_user_preferences(finance_engine, 1, "alien")
+
+    assert prefs["theme_mode"] == "dark"


### PR DESCRIPTION
## Summary
- add persistent user theme preferences
- store preferences in the database
- cover preference behavior with unit tests