### PR TITLE
feat: Add Docker fix, health endpoint, and CD workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/personalfinanceanalyzer:latest
+            ${{ secrets.DOCKER_USERNAME }}/personalfinanceanalyzer:${{ github.sha }}
+
+      - name: Deploy to Render
+        run: |
+          curl --request POST \
+               --url https://api.render.com/deploy/srv-${{ secrets.RENDER_SERVICE_ID }}?key=${{ secrets.RENDER_DEPLOY_KEY }} \
+               --header 'accept: application/json'
+        if: github.ref == 'refs/heads/main'
+
+  # Optional: Test the deployment health endpoint
+  health-check:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    
+    steps:
+      - name: Wait for deployment
+        run: sleep 30
+
+      - name: Check health endpoint
+        run: |
+          curl -f https://${{ secrets.RENDER_APP_URL }}/health || exit 1
+        retry-times: 3
+        retry-delay: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 # Start from an official Python image.
 # "slim" is a minimal variant — it has Python but strips out
 # many OS packages that we don't need, keeping the image small.
-# Always pin to a specific version (3.11-slim, not just "python")
+# Always pin to a specific version (3.12-slim, not just "python")
 # so the build is reproducible and won't break on a future update.
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # ─────────────────────────────────────────────
 # Install Poetry
@@ -51,7 +51,7 @@ COPY pyproject.toml poetry.lock ./
 # --no-interaction --no-ansi
 #   Disable prompts and colored output — appropriate for automated builds.
 RUN poetry config virtualenvs.create false \
-    && poetry install --only main --no-interaction --no-ansi –no-root
+    && poetry install --only main --no-interaction --no-ansi --no-root
 
 # ─────────────────────────────────────────────
 # Copy Application Source Code
@@ -63,22 +63,24 @@ RUN poetry config virtualenvs.create false \
 COPY . .
 
 # ─────────────────────────────────────────────
-# Expose Port
+# Make entrypoint script executable
+# ─────────────────────────────────────────────
+RUN chmod +x entrypoint.sh
+
+# ─────────────────────────────────────────────
+# Expose Ports
 # ─────────────────────────────────────────────
 # Streamlit listens on port 8501 by default.
+# Health check server listens on port 8502.
 # EXPOSE documents this for other developers and for Docker networking.
 # Note: EXPOSE alone does not publish the port to the host machine —
 # that requires -p 8501:8501 when running the container locally.
-EXPOSE 8501
+EXPOSE 8501 8502
 
 # ─────────────────────────────────────────────
 # Start Command
 # ─────────────────────────────────────────────
 # This is the command Docker runs when the container starts.
-# We launch Streamlit and explicitly set:
-#   --server.port=8501   match the port we declared above
-#   --server.address=0.0.0.0   listen on all network interfaces,
-#                               not just localhost — required so that
-#                               traffic from outside the container can reach it.
-CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+# We use an entrypoint script that runs both Streamlit and the health check server.
+ENTRYPOINT ["./entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Entrypoint script to run both Streamlit and health check server
+
+# Start health check server in background
+python src/health_check.py &
+HEALTH_PID=$!
+
+# Start Streamlit app in foreground
+streamlit run src/app.py --server.port=8501 --server.address=0.0.0.0
+
+# Cleanup on exit
+trap "kill $HEALTH_PID" EXIT

--- a/src/health_check.py
+++ b/src/health_check.py
@@ -1,0 +1,51 @@
+"""Simple health check endpoint for PersonalFinanceAnalyzer.
+
+This runs on a separate port (8502) to provide a dedicated health endpoint
+for monitoring services like UpTimeRobot.
+"""
+
+import json
+import logging
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for health check endpoint."""
+
+    def do_GET(self):
+        """Handle GET requests."""
+        if self.path == "/health":
+            response = {
+                "status": "healthy",
+                "timestamp": datetime.utcnow().isoformat(),
+                "service": "PersonalFinanceAnalyzer",
+            }
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(response).encode())
+            logger.info("Health check request successful")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        """Suppress default logging."""
+        pass
+
+
+def run_health_server(port: int = 8502) -> None:
+    """Start the health check server."""
+    server_address = ("0.0.0.0", port)
+    httpd = HTTPServer(server_address, HealthHandler)
+    logger.info(f"Health check server listening on port {port}")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("HEALTH_CHECK_PORT", "8502"))
+    run_health_server(port)


### PR DESCRIPTION
- Fix Dockerfile: Update Python from 3.11 to 3.12 to match pyproject.toml requirements
- Add health check endpoint: Create health_check.py with HTTP server on port 8502
- Add entrypoint script: Run both Streamlit app (8501) and health check (8502) concurrently
- Add deploy.yml: Create CI/CD workflow for building Docker image and deploying to Render
  - Build and push Docker image to Docker Hub
  - Deploy to Render using deployment hook
  - Health check endpoint verification after deployment