### PR TITLE
fix: replace invalid retry-times/retry-delay fields in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Check health endpoint
         run: |
-          curl -f https://${{ secrets.RENDER_APP_URL }}/health || exit 1
-        retry-times: 3
-        retry-delay: 10
+          for i in 1 2 3; do
+            curl -f https://${{ secrets.RENDER_APP_URL }}/health && exit 0
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          exit 1


### PR DESCRIPTION
retry-times and retry-delay are not valid GitHub Actions step fields, causing a workflow parse error.  Replaced with a shell for-loop that retries the health check up to 3 times with a 10-second delay.