### PR TITLE
fix: opt into Node.js 24 for GitHub Actions to silence deprecation wa…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
…rning

actions/checkout@v4, docker/login-action@v3, and docker/setup-buildx-action@v3 run on Node.js 20 which is deprecated and will be force-removed on September 16 2026.  Setting FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true on the job opts into Node.js 24 now so the warning disappears and the workflow is future-proof before the June 2 2026 forced cutover.